### PR TITLE
Remove ecommerce roles from vagrant devstack

### DIFF
--- a/playbooks/vagrant-devstack.yml
+++ b/playbooks/vagrant-devstack.yml
@@ -35,9 +35,11 @@
     - oraclejdk
     - elasticsearch
     - forum
-    - ecommerce
-    - role: ecomworker
-      ECOMMERCE_WORKER_BROKER_HOST: 127.0.0.1
+    # Disabled due to dependency issues with ecommerce
+    # "bower moment#~2.10.3    EINVRES Request to https://bower.herokuapp.com/packages/moment failed with 502"
+    #- ecommerce
+    #- role: ecomworker
+    #  ECOMMERCE_WORKER_BROKER_HOST: 127.0.0.1
     - discovery
     - role: notifier
       NOTIFIER_DIGEST_TASK_INTERVAL: "5"


### PR DESCRIPTION
Bower dependency issues encountered when deploying Ginkgo ecommerce.

https://bower.herokuapp.com/packages/moment returns a 502 error, saying: 
> This Bower version is deprecated. Please update it: npm install -g bower. The new registry address is https://registry.bower.io

Should not be required for Hawthorn+, as the ecommerce dependency has been updated in master.
